### PR TITLE
Return UUID on Weni Web Chat Channel endpoint

### DIFF
--- a/weni/grpc/channel/grpc_gen/channel_pb2.py
+++ b/weni/grpc/channel/grpc_gen/channel_pb2.py
@@ -18,7 +18,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     syntax="proto3",
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
-    serialized_pb=b'\n(weni/grpc/channel/grpc_gen/channel.proto\x12\x15weni.rapidpro.channel"H\n\x18WeniWebChatCreateRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04user\x18\x02 \x01(\t\x12\x10\n\x08\x62\x61se_url\x18\x03 \x01(\t"\x1b\n\x0bWeniWebChat\x12\x0c\n\x04name\x18\x01 \x01(\t2x\n\x15WeniWebChatController\x12_\n\x06\x43reate\x12/.weni.rapidpro.channel.WeniWebChatCreateRequest\x1a".weni.rapidpro.channel.WeniWebChat"\x00\x62\x06proto3',
+    serialized_pb=b'\n(weni/grpc/channel/grpc_gen/channel.proto\x12\x15weni.rapidpro.channel"H\n\x18WeniWebChatCreateRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04user\x18\x02 \x01(\t\x12\x10\n\x08\x62\x61se_url\x18\x03 \x01(\t"\x1b\n\x0bWeniWebChat\x12\x0c\n\x04uuid\x18\x01 \x01(\t2x\n\x15WeniWebChatController\x12_\n\x06\x43reate\x12/.weni.rapidpro.channel.WeniWebChatCreateRequest\x1a".weni.rapidpro.channel.WeniWebChat"\x00\x62\x06proto3',
 )
 
 
@@ -110,8 +110,8 @@ _WENIWEBCHAT = _descriptor.Descriptor(
     create_key=_descriptor._internal_create_key,
     fields=[
         _descriptor.FieldDescriptor(
-            name="name",
-            full_name="weni.rapidpro.channel.WeniWebChat.name",
+            name="uuid",
+            full_name="weni.rapidpro.channel.WeniWebChat.uuid",
             index=0,
             number=1,
             type=9,

--- a/weni/grpc/channel/serializers.py
+++ b/weni/grpc/channel/serializers.py
@@ -14,6 +14,7 @@ class WeniWebChatProtoSerializer(proto_serializers.ProtoSerializer):
     user = weni_serializers.UserEmailRelatedField(write_only=True)
     name = serializers.CharField()
     base_url = serializers.URLField(validators=[URLValidator(), validate_external_url], write_only=True)
+    uuid = serializers.UUIDField(read_only=True)
 
     def create(self, validated_data):
         user = validated_data["user"]
@@ -30,4 +31,4 @@ class WeniWebChatProtoSerializer(proto_serializers.ProtoSerializer):
 
     class Meta:
         proto_class = channel_pb2.WeniWebChat
-        fields = ["user", "name", "base_url"]
+        fields = ["user", "name", "base_url", "uuid"]

--- a/weni/grpc/channel/tests.py
+++ b/weni/grpc/channel/tests.py
@@ -20,7 +20,7 @@ class WeniWebChatCreateServiceTest(RPCTransactionTestCase):
         request_data = dict(name="fake wwc", user=self.user.email, base_url="https://dash.weni.ai")
         response = self.channel_create_request(**request_data)
 
-        channel = Channel.objects.get(name=response.name)
+        channel = Channel.objects.get(uuid=response.uuid)
         self.assertEqual(channel.created_by, self.user)
         self.assertEqual(channel.config[CONFIG_BASE_URL], request_data["base_url"])
 


### PR DESCRIPTION
The endpoint was returning `name` instead of channel UUID, this PR aims to solve it.