### PR TITLE
Adjust org reference on WeniWebChatProtoSerializer

### DIFF
--- a/weni/grpc/channel/serializers.py
+++ b/weni/grpc/channel/serializers.py
@@ -6,11 +6,12 @@ from temba.channels.models import Channel
 from temba.utils.fields import validate_external_url
 from temba.channels.types.weniwebchat.type import CONFIG_BASE_URL
 from weni.grpc.core import serializers as weni_serializers
-from weni.grpc.channel.grpc_gen import channel_pb2
+from weni.protobuf.flows import channel_pb2
 
 
 class WeniWebChatProtoSerializer(proto_serializers.ProtoSerializer):
 
+    org = weni_serializers.OrgUUIDRelatedField(write_only=True)
     user = weni_serializers.UserEmailRelatedField(write_only=True)
     name = serializers.CharField()
     base_url = serializers.URLField(validators=[URLValidator(), validate_external_url], write_only=True)
@@ -23,7 +24,7 @@ class WeniWebChatProtoSerializer(proto_serializers.ProtoSerializer):
         config = {CONFIG_BASE_URL: validated_data["base_url"]}
 
         return Channel.create(
-            user.get_org(), user, None, self._get_channel_type(), config=config, name=name, address=name
+            validated_data["org"], validated_data["user"], None, self._get_channel_type(), config=config, name=name, address=name
         )
 
     def _get_channel_type(self):

--- a/weni/grpc/channel/tests.py
+++ b/weni/grpc/channel/tests.py
@@ -2,8 +2,9 @@ from django.contrib.auth import get_user_model
 from django_grpc_framework.test import RPCTransactionTestCase
 
 from temba.channels.models import Channel
+from temba.orgs.models import Org
 from temba.channels.types.weniwebchat.type import CONFIG_BASE_URL
-from weni.grpc.channel.grpc_gen import channel_pb2, channel_pb2_grpc
+from weni.protobuf.flows import channel_pb2, channel_pb2_grpc
 
 
 User = get_user_model()
@@ -12,12 +13,13 @@ User = get_user_model()
 class WeniWebChatCreateServiceTest(RPCTransactionTestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="testuser", password="123", email="test@weni.ai")
+        self.org = Org.objects.create(name="Weni", timezone="Africa/Kigali", created_by=self.user, modified_by=self.user)
 
         super().setUp()
         self.stub = channel_pb2_grpc.WeniWebChatControllerStub(self.channel)
 
     def test_create_weni_web_chat_channel(self):
-        request_data = dict(name="fake wwc", user=self.user.email, base_url="https://dash.weni.ai")
+        request_data = dict(org=str(self.org.uuid), name="fake wwc", user=self.user.email, base_url="https://dash.weni.ai")
         response = self.channel_create_request(**request_data)
 
         channel = Channel.objects.get(uuid=response.uuid)

--- a/weni/grpc/channel/urls.py
+++ b/weni/grpc/channel/urls.py
@@ -1,4 +1,4 @@
-from weni.grpc.channel.grpc_gen import channel_pb2_grpc
+from weni.protobuf.flows import channel_pb2_grpc
 from weni.grpc.channel import services
 
 


### PR DESCRIPTION
`user.get_org()` was be returning `None`, a new field will add to solve this problem. `org` that receives an Org UUID

Proto file PR: https://github.com/Ilhasoft/weni-protobuffers/pull/39
Remember, for this Pull Request to be approved, you must also approve that of weni-protobuffers.