### PR TITLE
Bump to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+## [1.0.3] - 2021-10-28
+### Changed
+- `weni-protobuffers` updated to 1.2.1
+
+### Added
+- Channel release endpoint (#76)
+
 ## [1.0.2] - 2021-10-26
 ### Changed
 - `weni-protobuffers` updated to 1.2.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -472,7 +472,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "weni-protobuffers"
-version = "1.2.0"
+version = "1.2.1"
 description = "Protocol Buffers for Weni Platform"
 category = "main"
 optional = false
@@ -862,8 +862,8 @@ vine = [
     {file = "vine-1.3.0.tar.gz", hash = "sha256:133ee6d7a9016f177ddeaf191c1f58421a1dcc6ee9a42c58b34bed40e1d2cd87"},
 ]
 weni-protobuffers = [
-    {file = "weni-protobuffers-1.2.0.tar.gz", hash = "sha256:df240ee1be50f81c7d6bf34db003a6554d7562444d0b996c8a219dc44aa9ee8c"},
-    {file = "weni_protobuffers-1.2.0-py3-none-any.whl", hash = "sha256:023df4df157979573153c83d8c13ecfca6a5aa0b4d23363636f7dbf20bfe7a98"},
+    {file = "weni-protobuffers-1.2.1.tar.gz", hash = "sha256:97ab25a573b8194c34cfdaaf8e1f791a4c42126922cbd23746806b69dcfae289"},
+    {file = "weni_protobuffers-1.2.1-py3-none-any.whl", hash = "sha256:a09844bc888a5a061872000160192694e9237d40b409fb60eba4ef2a225379d8"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-rp-apps"
-version = "1.0.2"
+version = "1.0.3"
 description = "Weni apps for Rapidpro Platform"
 authors = ["jcbalmeida"]
 license = "AGPL-3.0"


### PR DESCRIPTION
Main updates:
- Bump weni-rp-apps to 1.0.3
- Update [weni-protobuffers](https://pypi.org/project/weni-protobuffers/1.2.1/) to 1.2.1