### PR TITLE
Add possibility of return Empty

### DIFF
--- a/weni/grpc/billing/queries.py
+++ b/weni/grpc/billing/queries.py
@@ -84,6 +84,9 @@ class MessageDetailQuery:
             .last()
         )
 
+        if not msg:
+            return None
+
         channel = Channel.objects.get(id=msg["channel"])
 
         msg["channel_id"] = channel.id

--- a/weni/grpc/billing/queries.py
+++ b/weni/grpc/billing/queries.py
@@ -85,11 +85,12 @@ class MessageDetailQuery:
         )
 
         if not msg:
-            return None
+            return dict(uuid = "", text = "", created_on = "", direction = "", channel_id = 0, channel_type = "", is_valid = False)
 
         channel = Channel.objects.get(id=msg["channel"])
 
         msg["channel_id"] = channel.id
         msg["channel_type"] = channel.channel_type
+        msg["is_valid"] = True
 
         return msg

--- a/weni/grpc/billing/serializers.py
+++ b/weni/grpc/billing/serializers.py
@@ -92,6 +92,7 @@ class MsgDetailSerializer(ProtoSerializer):
     direction = serializers.CharField()
     channel_id = serializers.IntegerField()
     channel_type = serializers.CharField()
+    is_valid = serializers.BooleanField()
 
     class Meta:
         proto_class = billing_pb2.MsgDetail

--- a/weni/grpc/billing/services.py
+++ b/weni/grpc/billing/services.py
@@ -50,9 +50,6 @@ class BillingService(generics.GenericService):
 
         msg = MessageDetailQuery.incoming_message(org_uuid, contact_uuid, before, after)
 
-        if not msg:
-            return empty_pb2.Empty()
-
         msg_serializer = MsgDetailSerializer(msg)
         return msg_serializer.message
         

--- a/weni/grpc/billing/services.py
+++ b/weni/grpc/billing/services.py
@@ -10,6 +10,7 @@ from weni.grpc.billing.serializers import (
     MessageDetailRequestSerializer,
 )
 
+from google.protobuf import empty_pb2
 
 class BillingService(generics.GenericService):
 
@@ -49,6 +50,9 @@ class BillingService(generics.GenericService):
 
         msg = MessageDetailQuery.incoming_message(org_uuid, contact_uuid, before, after)
 
-        msg_serializer = MsgDetailSerializer(msg)
+        if not msg:
+            return empty_pb2.Empty()
 
+        msg_serializer = MsgDetailSerializer(msg)
         return msg_serializer.message
+        

--- a/weni/grpc/billing/tests.py
+++ b/weni/grpc/billing/tests.py
@@ -14,6 +14,7 @@ from weni.protobuf.flows import billing_pb2 as pb2, billing_pb2_grpc as stubs
 from weni.grpc.billing.queries import ActiveContactsQuery
 from weni.grpc.billing.serializers import BillingRequestSerializer, ActiveContactDetailSerializer
 from django_grpc_framework.test import FakeRpcError, RPCTransactionTestCase
+from google.protobuf import empty_pb2
 
 
 class ActiveContactsQueryTest(TembaTest):
@@ -252,6 +253,27 @@ class BillingServiceTest(RPCTransactionTestCase, TembaTest):
         self.assertEqual(msg.direction, result.direction)
         self.assertEqual(channel.id, result.channel_id)
         self.assertEqual(channel.channel_type, result.channel_type)
+
+    def test_message_detail_fail(self):
+        user = User.objects.create_user(username="testuser", password="123", email="test@weni.ai")
+        org = Org.objects.create(name="Temba", timezone="Africa/Kigali", created_by=user, modified_by=user)
+
+        contact = self.create_contact(f"Contact 1", phone=f"+553124826922")
+        contact.org = org
+        contact.save(update_fields=["org"])
+
+        channel = self.create_channel(channel_type="WA", name="channel_test", address="address_test", org=org)
+
+        msg = self.create_outgoing_msg(contact=contact, text="incoming message test", channel=channel, status="F")
+
+        before = tz.now()
+        after = tz.now() - tz.timedelta(minutes=1)
+
+        result = self.billing_detail_msg(
+            org_uuid=str(org.uuid), contact_uuid=str(contact.uuid), before=str(before), after=str(after)
+        )
+
+        self.assertEqual(type(result), empty_pb2.Empty)
 
     def billing_detail_msg(self, **kwargs):
         return self.stub.MessageDetail(pb2.MessageDetailRequest(**kwargs))

--- a/weni/grpc/billing/tests.py
+++ b/weni/grpc/billing/tests.py
@@ -253,6 +253,7 @@ class BillingServiceTest(RPCTransactionTestCase, TembaTest):
         self.assertEqual(msg.direction, result.direction)
         self.assertEqual(channel.id, result.channel_id)
         self.assertEqual(channel.channel_type, result.channel_type)
+        self.assertEqual(True, result.is_valid)
 
     def test_message_detail_fail(self):
         user = User.objects.create_user(username="testuser", password="123", email="test@weni.ai")
@@ -273,7 +274,7 @@ class BillingServiceTest(RPCTransactionTestCase, TembaTest):
             org_uuid=str(org.uuid), contact_uuid=str(contact.uuid), before=str(before), after=str(after)
         )
 
-        self.assertEqual(type(result), empty_pb2.Empty)
+        self.assertEqual(result.is_valid, False)
 
     def billing_detail_msg(self, **kwargs):
         return self.stub.MessageDetail(pb2.MessageDetailRequest(**kwargs))


### PR DESCRIPTION
# Resume
Sometimes, if has not contact in a period of time, it can cause an error.

### Solution
I created a new field in protobuf called "is_valid", so if the response is not ok, it will return a empty object with is_valid = False

```
System check identified no issues (0 silenced).
....
----------------------------------------------------------------------
Ran 4 tests in 1.380s
OK
```

reference: https://github.com/Ilhasoft/weni-protobuffers/pull/78