### PR TITLE
Adjust the org field in the channel listing return

### DIFF
--- a/weni/internal/channel/serializers.py
+++ b/weni/internal/channel/serializers.py
@@ -148,5 +148,5 @@ class ChannelSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)
-        ret['org'] = instance.uuid
+        ret['org'] = instance.org.uuid
         return ret


### PR DESCRIPTION
The UUID being returned was for the channel rather than the org. this PR aims to solve this problem