### PR TITLE
Add agent permission in get_permissions method

### DIFF
--- a/weni/internal/users/views.py
+++ b/weni/internal/users/views.py
@@ -99,6 +99,7 @@ class UserPermissionEndpoint(InternalGenericViewSet):
             "viewer": org.viewers,
             "editor": org.editors,
             "surveyor": org.surveyors,
+            "agent": org.agents,
         }
 
     def _get_user_permissions(self, org: Org, user: User) -> dict:


### PR DESCRIPTION
This correction solves the problem where users linked as agent in the project did not appear in the human service cards