### PR TITLE
fix: clear dependencies from initial migration

### DIFF
--- a/weni/internal/migrations/0001_initial.py
+++ b/weni/internal/migrations/0001_initial.py
@@ -7,9 +7,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
     initial = True
 
-    dependencies = [
-        ("tickets", "0025_remove_ticket_subject"),
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(


### PR DESCRIPTION
this `0025_remove_ticket_subject` dependency on initial migration is crashing Ilhasoft/rapidpro migrations